### PR TITLE
Spotify links

### DIFF
--- a/src/_data/site.yaml
+++ b/src/_data/site.yaml
@@ -78,6 +78,7 @@ social:
     url: 'https://speakerdeck.com/fevr'
   patreon:
     name: Patreon
+    icon: eur
     url: 'https://www.patreon.com/fevr'
   spotify:
     name: Spotify

--- a/src/_data/site.yaml
+++ b/src/_data/site.yaml
@@ -79,6 +79,9 @@ social:
   patreon:
     name: Patreon
     url: 'https://www.patreon.com/fevr'
+  spotify:
+    name: Spotify
+    url: https://open.spotify.com/show/24e51pmI7X0UXfIgRQiyMX
 
 team:
   - name: 'Matteo Guidotto'

--- a/src/_includes/event-content.njk
+++ b/src/_includes/event-content.njk
@@ -54,6 +54,13 @@
           >
             </li>
           {% endif %}
+          {% if event.spotifypodcast %}
+            <li>
+              <a href="{{event.spotifypodcast}}" class="btn btn-primary" target="_blank"
+            >Podcast evento</a
+          >
+            </li>
+          {% endif %}
           {% if event.slides %}
             {%- for slide in event.slides %}
               <li>

--- a/src/index.njk
+++ b/src/index.njk
@@ -26,7 +26,7 @@ isHome: true
               <a href="{{site.social.facebook.url}}" target="_blank" class="btn blue-btn">Facebook</a>
               <a href="{{site.social.slack.url}}" target="_blank" class="btn red-btn">Slack</a>
               <a href="{{site.social.twitter.url}}" target="_blank" class="btn blue-btn">Twitter</a>
-              <a href="{{site.social.patreon.url}}" target="_blank" class="btn red-btn">Patreon</a>
+              <a href="{{site.social.spotify.url}}" target="_blank" class="btn red-btn">Spotify</a>
 
             </p>
           </div>

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -68,6 +68,10 @@ collections:
             label: Link Live Facebook
             required: false
           - widget: string
+            name: spotifypodcast
+            label: Link Episodio Podcast Spotify
+            required: false
+          - widget: string
             name: foto
             label: Link Foto
             required: false


### PR DESCRIPTION
- Removed Patreon link on the HP hero and replaced with the link to Spotify podcast
- Patreon icon on contact pages
- Event podcast link (optional) on the event frontmatter (+ CMS config)